### PR TITLE
Reconcile production metadata and backup diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pay-per-query data APIs for AI agents. No accounts, no API keys, no subscription
 **Docs:** https://api.devdrops.run/openapi.json  
 **Catalog:** https://api.devdrops.run/catalog
 
-25 production endpoints serving prediction markets, sports odds, financial data, regulatory filings, weather, FX rates, crypto prices, QR codes, timezones, AI sentiment, and more — all paid via x402 micropayments on Base mainnet.
+43 production products/endpoints serving prediction markets, sports odds, financial data, regulatory filings, weather, FX rates, crypto prices, QR codes, timezones, utility wrappers, MCP tools, AI sentiment, and more — paid via x402 micropayments on Base mainnet, with a small free tier on selected utility endpoints.
 
 ## Quick start
 
@@ -42,11 +42,17 @@ See https://devdrops.run for more examples.
 
 - Project wiki: `wiki/PROJECT.md`
 - Current state: `wiki/STATE.md`
+- Production audit: `docs/devdrops-production-audit.md`
+- Endpoint matrix: `docs/devdrops-endpoint-matrix.md`
+- Distribution checklist: `docs/devdrops-distribution-checklist.md`
 
 ## Deploy
 
 ```bash
 npm install
+npm run typecheck
+npm test
+npm run smoke:metadata
 npx wrangler deploy
 ```
 

--- a/docs/devdrops-backup-runbook.md
+++ b/docs/devdrops-backup-runbook.md
@@ -1,0 +1,39 @@
+# DevDrops Backup Runbook
+
+## Current Status
+
+R2 backups are implemented but optional. Production `/health` reports:
+
+- `checks.r2: not_configured`
+- `backup.status: skipped`
+- `backup.reason: R2 binding STORAGE is not configured; nightly backup cron exits without writing.`
+
+This is a safe degraded state. D1/KV continue to operate.
+
+## Enabling R2 Backups
+
+Only enable when the R2 bucket exists and the Cloudflare binding is ready.
+
+1. Create/verify R2 bucket: `devdrops-backups`.
+2. Add the `STORAGE` binding in `wrangler.toml` and `wrangler.jsonc`.
+3. Deploy.
+4. Confirm `/health` reports `checks.r2: ok` and `backup.status: ready`.
+5. Wait for the existing nightly cron or manually invoke a safe preview only if Cloudflare supports it.
+
+## Backup Scope
+
+The backup job exports:
+
+- `transactions`
+- `abandoned_402s`
+- `health_log`
+- `data_sources`
+- `product_cache`
+
+Retention: 90 days.
+
+## Restore Posture
+
+This repository does not include an automated destructive restore command. Any restore should be explicit, reviewed, and table-specific.
+
+Do not drop, truncate, or overwrite production D1 tables without explicit approval.

--- a/docs/devdrops-cost-governance.md
+++ b/docs/devdrops-cost-governance.md
@@ -1,0 +1,42 @@
+# DevDrops Cost Governance
+
+## AI And Paid Upstream Posture
+
+DevDrops includes paid or usage-sensitive surfaces:
+
+- Claude-backed routes: sentiment, signals, documents, research, summarize/classify/entities where configured
+- Workers AI routes: image generation and inference
+- Odds API: paid upstream
+- Stripe/credits: payment-dependent
+- x402 facilitator: payment verification path
+
+No real AI or paid x402 transaction should run in CI.
+
+## Safe Validation
+
+Use metadata smoke:
+
+```bash
+npm run smoke:metadata
+```
+
+This checks only free discovery/health surfaces.
+
+## Cost Controls To Preserve
+
+- Product prices must remain visible in `/catalog`, `/openapi.json`, and `/.well-known/x402`.
+- AI routes should return clear missing-key or upstream errors rather than silently retrying expensive calls.
+- Free-tier endpoints should remain bounded.
+- Cron should not perform AI work.
+- Paid upstream dependencies should be documented before adding new modules.
+
+## Recommended Next Improvement
+
+Add a read-only cost dashboard backed by D1 transaction rows:
+
+- daily revenue
+- x402 paid calls
+- abandoned 402s
+- AI route count
+- upstream error count
+- estimated AI/provider cost by product

--- a/docs/devdrops-distribution-checklist.md
+++ b/docs/devdrops-distribution-checklist.md
@@ -1,0 +1,43 @@
+# DevDrops Distribution Checklist
+
+Date: 2026-05-06
+
+## Discovery Surfaces
+
+- `/catalog` — live, 43 products
+- `/catalog.json` — live machine-readable catalog alias
+- `/openapi.json` — live OpenAPI 3.1
+- `/.well-known/x402` — live x402 discovery manifest
+- `/.well-known/mcp.json` — live MCP discovery manifest
+- `/.well-known/mcp/server-card.json` — live Smithery-compatible server card
+- `/llms.txt` — redirects to `/.well-known/llms.txt`
+
+## External Distribution
+
+| Channel | Status | Next action |
+|---|---|---|
+| Coinbase x402 Bazaar | Earlier docs reference `coinbase/x402#38` | Check PR status manually before refreshing listing |
+| awesome-x402 | Earlier docs reference `xpaysh/awesome-x402#209` | Check PR status manually before refreshing listing |
+| x402scan | Pending first paid transaction visibility | Run one explicitly approved paid transaction when ready |
+| MCP registry / Smithery | Manifest and server card now exist | Submit using `/.well-known/mcp.json` and `/.well-known/mcp/server-card.json` |
+| RapidAPI | Distribution copy exists | Keep as marketing surface only; do not make RapidAPI the product dependency |
+
+## First Paid Transaction Path
+
+Do not run this automatically. When explicitly approved:
+
+1. Pick a low-cost endpoint from `/catalog`.
+2. Use a funded Base wallet with the x402 client.
+3. Confirm the endpoint first returns HTTP 402.
+4. Submit payment proof.
+5. Confirm HTTP 200 response.
+6. Confirm transaction appears in D1 `transactions`.
+7. Check x402scan indexing after settlement.
+
+## Safety
+
+- Do not expose wallet private keys.
+- Do not commit payment secrets.
+- Do not add free production bypasses for paid endpoints.
+- Do not run paid transactions as CI.
+- Keep metadata/discovery endpoints free.

--- a/docs/devdrops-endpoint-matrix.md
+++ b/docs/devdrops-endpoint-matrix.md
@@ -1,0 +1,74 @@
+# DevDrops Endpoint Reliability Matrix
+
+Date: 2026-05-06
+
+Source of truth: production `/catalog` plus route/pricing configuration.
+
+## Summary
+
+- Current catalog count: 43 products/endpoints
+- x402 discovery: live
+- OpenAPI: live
+- Free metadata smoke: available via `npm run smoke:metadata`
+- No paid calls are required for metadata validation
+
+## Matrix
+
+| Product | Representative endpoint | Price | Category | Upstream class | Risk notes |
+|---|---|---:|---|---|---|
+| Property Intelligence | `/api/property/uk/prices` | $0.01 | Domain Expertise | self-contained/public property data | England/Wales data freshness limitations |
+| Property MCP | `/api/property/mcp` | $0.01 | MCP+Skills | self-contained/MCP wrapper | GET discovery free; POST tool calls paid |
+| Prediction Markets | `/api/predictions/markets` | $0.005 | Data Aggregation | no-key public APIs | upstream availability varies |
+| Sports Odds | `/api/odds/sports` | $0.005 | Data Aggregation | paid key | Odds API quota/cost exposure |
+| Regulatory Feeds | `/api/regulatory/search` | $0.01 | Data Aggregation | free key/government APIs | Companies House key required |
+| Events Calendar | `/api/calendar/upcoming` | $0.005 | Data Aggregation | scrape-dependent | monitor markup changes |
+| Company Filings | `/api/filings/search` | $0.01 | Data Aggregation | free key/government APIs | not legal advice |
+| Domain Lookup | `/api/domain/lookup/:domain` | $0.005 | Data Aggregation | no-key public protocols | RDAP/CT availability varies |
+| Weather | `/api/weather/current` | $0.001 | Data Aggregation | free key | free-tier eligible; weather key required |
+| FX Rates | `/api/fx/latest` | $0.001 | Data Aggregation | no-key public API | free-tier eligible |
+| IP Geolocation | `/api/ip/me` | $0.001 | Data Aggregation | free key | free-tier eligible; IPinfo quota |
+| History | `/api/history/today` | $0.001 | Data Aggregation | no-key public API | free-tier eligible |
+| Academic Papers | `/api/papers/search` | $0.005 | Data Aggregation | no-key public APIs | OpenAlex/Semantic Scholar availability |
+| Food & Nutrition | `/api/food/search` | $0.005 | Data Aggregation | no-key public API | health/nutrition data should be informational only |
+| Public Tenders | `/api/tenders/search` | $0.01 | Data Aggregation | free public/government APIs | SAM.gov key may improve coverage |
+| News Sentiment | `/api/sentiment/analyze` | $0.02 | AI-Enhanced | Claude-dependent | paid AI; cache/cost controls matter |
+| Market Signals | `/api/signals/correlate` | $0.05 | AI-Enhanced | Claude-dependent | paid AI; not financial advice |
+| Document Summarise | `/api/documents` | $0.10 | AI-Enhanced | Claude-dependent | paid AI; input size/cost risk |
+| Location Intelligence | `/api/location/uk/report` | $0.02 | AI-Enhanced | public/keyed sources | UK-only assumptions |
+| Research Brief | `/api/research/brief` | $0.10 | AI-Enhanced | Claude-dependent | paid AI; source limitations |
+| Translation | `/api/translate` | $0.005 | Utility | public instance/self-hostable | public LibreTranslate reliability varies |
+| Email Verify | `/api/email-verify/check/:email` | $0.005 | Utility | DNS/self-contained | no email sending |
+| QR Generator | `/api/qr/generate` | $0.001 | Utility | no-key/public utility | free-tier eligible |
+| Crypto Prices | `/api/crypto/price/bitcoin` | $0.001 | Utility | no-key public API | not financial advice |
+| Time & Timezone | `/api/time/now` | $0.001 | Utility | self-contained/free public holidays | free-tier eligible |
+| VAT Check | `/api/vat/check/:number` | $0.01 | Intelligence | no-key government APIs | not tax advice |
+| Stock Quotes | `/api/stocks/quote/:ticker` | $0.005 | Intelligence | unofficial/free upstream | not financial advice; upstream fragility |
+| Content Extract | `/api/extract/url` | $0.005 | Intelligence | controlled public fetch | SSRF guard required; ToS sensitivity |
+| Sanctions Screen | `/api/sanctions/check` | $0.05 | Intelligence | public government lists | not compliance determination |
+| Company Enrichment | `/api/company/search` | $0.02 | Intelligence | free key/government API | UK Companies House focus |
+| ASN / BGP | `/api/asn/ip/:ip` | $0.005 | Data Aggregation | no-key public API | upstream rate limits |
+| Economic Indicators | `/api/economy/indicator` | $0.005 | Data Aggregation | no-key public API | World Bank coverage gaps |
+| Image Generate | `/api/image/generate` | $0.02 | AI-Enhanced | Workers AI-dependent | paid AI/platform usage |
+| LLM Complete | `/api/inference/complete` | $0.005 | AI-Enhanced | Workers AI-dependent | paid AI/platform usage |
+| LLM Chat | `/api/inference/chat` | $0.005 | AI-Enhanced | Workers AI-dependent | paid AI/platform usage |
+| Utilities | `/api/utils/uuid` | $0.001 | Utility | self-contained | low risk |
+| Summarize URL | `/api/summarize/url` | $0.02 | AI-Enhanced | public fetch + Claude | paid AI; ToS/source constraints |
+| Text Classify | `/api/classify` | $0.02 | AI-Enhanced | Claude-dependent | paid AI |
+| Entity Extract | `/api/entities` | $0.02 | AI-Enhanced | Claude-dependent | paid AI |
+| Universal MCP | `/api/mcp` | $0.01 | MCP+Skills | wrapper/payment-dependent | discovery free; tool calls paid |
+| Starter Bundle | `/api/credits/purchase/starter` | $5.00 | Credits | Stripe/payment-dependent | no secret exposure |
+| Pro Bundle | `/api/credits/purchase/pro` | $25.00 | Credits | Stripe/payment-dependent | no secret exposure |
+| Business Bundle | `/api/credits/purchase/business` | $100.00 | Credits | Stripe/payment-dependent | no secret exposure |
+
+## Smoke Test Policy
+
+Metadata smoke tests should call only:
+
+- `/health`
+- `/catalog`
+- `/openapi.json`
+- `/.well-known/x402`
+- `/.well-known/mcp.json`
+- `/.well-known/mcp/server-card.json`
+
+Product endpoint smoke tests should accept either `200` for free-tier availability or `402` for payment-required responses. Do not run paid x402 transactions automatically.

--- a/docs/devdrops-production-audit.md
+++ b/docs/devdrops-production-audit.md
@@ -1,0 +1,93 @@
+# DevDrops Production Audit
+
+Date: 2026-05-06
+
+## Executive Status
+
+DevDrops is live as a Cloudflare Workers/x402 API product. The current production metadata surfaces report 43 products/endpoints, not the older 22/25/30-module counts in legacy docs.
+
+Live surfaces checked:
+
+- `https://api.devdrops.run/health`
+- `https://api.devdrops.run/catalog`
+- `https://api.devdrops.run/openapi.json`
+- `https://api.devdrops.run/.well-known/x402`
+- `https://api.devdrops.run/.well-known/mcp.json`
+- `https://api.devdrops.run/.well-known/mcp/server-card.json`
+
+## Endpoint Count Reconciliation
+
+| Source | Count | Status |
+|---|---:|---|
+| Legacy wiki launch copy | 22 | Superseded |
+| Later wiki state | 30 | Superseded |
+| README before this audit | 25 | Superseded |
+| Production `/catalog` | 43 | Current source of truth |
+| Production OpenAPI positioning | 43 | Current |
+| Production x402 manifest positioning | 43 | Current |
+
+The 43 count includes utility wrappers, AI endpoints, MCP, and credit bundle products. Utility wrappers remain in scope because accountless wallet-payable wrappers are part of the DevDrops product.
+
+## Live Infrastructure
+
+| Component | Observed status | Notes |
+|---|---|---|
+| Worker | Live | `api.devdrops.run` responds |
+| D1 | ok | `/health` reports D1 ok |
+| KV | ok | `/health` reports KV ok |
+| R2 | not_configured | Optional backup binding is absent; backup cron skips safely |
+| x402 manifest | live | `/.well-known/x402` responds |
+| OpenAPI | live | `/openapi.json` responds |
+| Catalog | live | `/catalog` reports 43 products |
+| MCP manifest | live | `/.well-known/mcp.json` and server card respond |
+
+## Payment And Settlement
+
+- x402 middleware is mounted for `/api/*` product routes.
+- Checkout/webhook and selected discovery routes intentionally bypass x402.
+- Production network is Base mainnet: `eip155:8453`.
+- Facilitator URL points to Coinbase CDP x402.
+- No wallet/private keys are stored in the repository.
+- No paid transaction was run during this audit.
+
+## Cost Exposure
+
+| Area | Cost posture |
+|---|---|
+| Cloudflare Workers/D1/KV | expected platform cost |
+| R2 backups | currently skipped because binding is absent |
+| Claude/AI routes | paid per actual request; no audit run called paid AI |
+| The Odds API | configured as paid upstream in docs |
+| Workers AI routes | paid platform feature if called |
+| Metadata smoke | free surfaces only |
+
+## Security And Safety Risks
+
+- Secret values are referenced only as environment bindings, not committed.
+- `wrangler.toml` and `wrangler.jsonc` contain non-secret public config, including the public pay-to wallet address.
+- `/health` now exposes backup readiness without secret values.
+- Admin sanctions refresh route requires cron context or `ADMIN_SECRET`.
+
+## Observability Gaps
+
+- R2 backup readiness was previously only visible in logs; `/health` now includes a `backup` diagnostic object.
+- Live smoke tests cover free metadata and selected route behavior, but there is no automated paid-transaction test.
+- There is no customer-facing revenue dashboard yet.
+
+## Revenue And Distribution Blockers
+
+- R2 backup binding remains absent.
+- x402scan appearance still depends on a first paid transaction.
+- External marketplace PRs need periodic manual review.
+- MCP registry submission should use the existing manifests.
+
+## Validation Commands
+
+```bash
+npm run typecheck
+npm test
+npm run smoke:metadata
+npx wrangler deploy --dry-run
+```
+
+No destructive D1 changes, paid upstream changes, real AI calls, or wallet/private-key exposure were performed in this audit.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "deploy": "wrangler deploy",
     "db:init": "wrangler d1 execute devdrops --local --file=src/db/schema.sql",
     "db:init:remote": "wrangler d1 execute devdrops --remote --file=src/db/schema.sql",
+    "typecheck": "tsc --noEmit",
+    "smoke:metadata": "node scripts/smoke-metadata.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/smoke-metadata.mjs
+++ b/scripts/smoke-metadata.mjs
@@ -1,0 +1,60 @@
+const BASE = process.env.DEVDROPS_BASE || "https://api.devdrops.run";
+
+async function readJson(path) {
+  const started = Date.now();
+  const response = await fetch(`${BASE}${path}`);
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`${path} did not return JSON: ${text.slice(0, 120)}`);
+  }
+  return { path, status: response.status, ms: Date.now() - started, body };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const checks = [];
+checks.push(await readJson("/health"));
+checks.push(await readJson("/catalog"));
+checks.push(await readJson("/openapi.json"));
+checks.push(await readJson("/.well-known/x402"));
+checks.push(await readJson("/.well-known/mcp.json"));
+checks.push(await readJson("/.well-known/mcp/server-card.json"));
+
+const health = checks.find((c) => c.path === "/health").body;
+const catalog = checks.find((c) => c.path === "/catalog").body;
+const openapi = checks.find((c) => c.path === "/openapi.json").body;
+const x402 = checks.find((c) => c.path === "/.well-known/x402").body;
+const mcp = checks.find((c) => c.path === "/.well-known/mcp.json").body;
+const serverCard = checks.find((c) => c.path === "/.well-known/mcp/server-card.json").body;
+
+assert(["healthy", "degraded"].includes(health.status), "health.status should be healthy or degraded");
+assert(health.checks?.d1, "health should include d1 check");
+assert(health.checks?.kv, "health should include kv check");
+const backup = health.backup ?? {
+  configured: null,
+  status: "not_deployed",
+  reason: "Production health has not yet deployed backup readiness diagnostics.",
+};
+assert(catalog.product_count === 43, `catalog product_count expected 43, got ${catalog.product_count}`);
+assert(Array.isArray(catalog.products) && catalog.products.length === 43, "catalog should expose 43 products");
+assert(openapi.openapi?.startsWith("3."), "openapi should be v3");
+assert(openapi.info?.description?.includes("43 pay-per-query"), "openapi description should reflect 43 products");
+assert(x402.version === "x402/1", "x402 manifest should declare x402/1");
+assert(Array.isArray(x402.endpoints) && x402.endpoints.length >= 43, "x402 manifest should expose endpoints");
+assert(mcp.api?.type === "mcp", "mcp.json should describe MCP API");
+assert(Array.isArray(mcp.tools) && mcp.tools.length === 18, "mcp.json should expose 18 tools");
+assert(serverCard.serverInfo?.name === "devdrops", "server card should identify devdrops");
+
+console.log(JSON.stringify({
+  base: BASE,
+  checks: checks.map(({ path, status, ms }) => ({ path, status, ms })),
+  product_count: catalog.product_count,
+  x402_endpoints: x402.endpoints.length,
+  mcp_tools: mcp.tools.length,
+  backup,
+}, null, 2));

--- a/src/cron/backup.ts
+++ b/src/cron/backup.ts
@@ -3,10 +3,20 @@ import type { Env } from "../types";
 const TABLES = ["transactions", "abandoned_402s", "health_log", "data_sources", "product_cache"];
 const RETENTION_DAYS = 90;
 
+export function getBackupReadiness(env: Env) {
+  return {
+    configured: Boolean(env.STORAGE),
+    status: env.STORAGE ? "ready" : "skipped",
+    reason: env.STORAGE ? null : "R2 binding STORAGE is not configured; nightly backup cron exits without writing.",
+    retention_days: RETENTION_DAYS,
+    tables: TABLES,
+  };
+}
+
 export async function runBackup(env: Env) {
   const storage = env.STORAGE;
   if (!storage) {
-    console.log("Backup skipped: R2 bucket not configured yet");
+    console.log(getBackupReadiness(env).reason);
     return;
   }
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
+import { getBackupReadiness } from "../cron/backup";
 
 const health = new Hono<{ Bindings: Env }>();
 
@@ -42,6 +43,7 @@ health.get("/", async (c) => {
     {
       status: allOk ? "healthy" : "degraded",
       checks,
+      backup: getBackupReadiness(c.env),
       environment: c.env.ENVIRONMENT,
       latency_ms: Date.now() - start,
       timestamp: new Date().toISOString(),

--- a/src/test/smoke.test.ts
+++ b/src/test/smoke.test.ts
@@ -41,7 +41,8 @@ describe("landing + free routes", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as any;
     expect(Array.isArray(json.products)).toBe(true);
-    expect(json.products.length).toBeGreaterThanOrEqual(25);
+    expect(json.product_count).toBe(43);
+    expect(json.products.length).toBe(43);
     const first = json.products[0];
     expect(first).toHaveProperty("endpoint");
     expect(first).toHaveProperty("price");

--- a/wiki/PROJECT.md
+++ b/wiki/PROJECT.md
@@ -1,12 +1,12 @@
 # DevDrops — Project Wiki
 
-> Last updated: 2026-04-06
+> Last updated: 2026-05-06
 
 ---
 
 ## Overview
 
-**DevDrops** (`devdrops.run`) is a suite of 22 pay-per-query data APIs powered by the x402 micropayment protocol. AI agents and developers send a standard HTTP request, receive an HTTP 402 response with a USDC price, pay on Base (Coinbase's L2), and instantly receive structured JSON data. No API keys, no subscriptions, no accounts.
+**DevDrops** (`devdrops.run`) is a suite of 43 pay-per-query products/endpoints powered by the x402 micropayment protocol. AI agents and developers send a standard HTTP request, receive an HTTP 402 response with a USDC price, pay on Base (Coinbase's L2), and instantly receive structured JSON data. No API keys, no subscriptions, no accounts.
 
 **Landing page:** https://devdrops.run  
 **API base:** https://api.devdrops.run  
@@ -62,7 +62,7 @@ src/
 │   ├── catalog.ts        — GET /catalog — machine-readable product list
 │   ├── openapi.ts        — GET /openapi.json — OpenAPI 3.1 spec
 │   ├── well-known.ts     — GET /.well-known/x402 — agent discovery manifest
-│   └── [22 product routers]
+│   └── [43 advertised products/endpoints across the mounted route modules]
 ├── cron/
 │   ├── handler.ts        — Scheduled event dispatcher
 │   ├── health-check.ts   — Pings all data_sources, auto-failover on 3 failures
@@ -91,7 +91,17 @@ src/
 
 ---
 
-## Products (22 — all live)
+## Products
+
+The current live source of truth is the machine-readable catalog:
+
+- `https://api.devdrops.run/catalog`
+- `https://api.devdrops.run/openapi.json`
+- `https://api.devdrops.run/.well-known/x402`
+
+As of 2026-05-06 the catalog reports **43 products/endpoints**. Older 22/25/30 references are superseded by the catalog and the production audit docs.
+
+## Original 22-Product Launch Set
 
 ### Tier 1 — Domain Expertise
 

--- a/wiki/STATE.md
+++ b/wiki/STATE.md
@@ -1,16 +1,27 @@
 # DevDrops — Current State
 
-> Last updated: 2026-04-07
+> Last updated: 2026-05-06
 
 ---
 
 ## Summary
 
-DevDrops launched with 25 planned modules. After research and viability checks, **30 are live** and **3 were dropped**. All 30 live modules return HTTP 402 with a USDC price on Base mainnet, verified working.
+DevDrops launched from an earlier 25/30-module plan. The current production catalog reports **43 products/endpoints** and is now the source of truth. Live metadata surfaces are:
+
+- `/catalog` — 43 products
+- `/openapi.json` — OpenAPI 3.1 with 43-product positioning
+- `/.well-known/x402` — x402 discovery manifest
+- `/.well-known/mcp.json` and `/.well-known/mcp/server-card.json` — MCP discovery
+
+Older 25/30 wording is superseded by the current catalog and the production audit docs.
 
 ---
 
-## Live Modules (30)
+## Live Modules
+
+See `docs/devdrops-endpoint-matrix.md` for the current 43-product matrix.
+
+## Original 30-Module Baseline
 
 ### Tier 1 — Domain Expertise
 


### PR DESCRIPTION
## Summary
- Reconciles DevDrops docs/wiki/README around the current production catalog count of 43 products/endpoints.
- Adds production audit, endpoint matrix, distribution checklist, backup runbook, and cost-governance docs.
- Adds a free metadata smoke script for /health, /catalog, /openapi.json, x402, and MCP manifests.
- Exposes backup readiness in /health without enabling R2 or changing cron schedules.

## Validation
- npm install
- npm run typecheck
- npm test
- npm run smoke:metadata
- npx wrangler deploy --dry-run --env=""

## Safety summary
- Destructive D1 changes: no
- R2 binding enabled: no
- Cron schedule changed/enabled: no
- Paid x402 transaction run: no
- Real AI call run: no
- Wallet/private key exposed: no
- Payment middleware changed: no
- Product pricing changed: no
- New paid upstream dependency: no
