### PR TITLE
Add R2 backup readiness workflow

### DIFF
--- a/.github/workflows/r2-readiness.yml
+++ b/.github/workflows/r2-readiness.yml
@@ -1,0 +1,29 @@
+name: R2 Backup Readiness
+
+on:
+  workflow_dispatch:
+
+jobs:
+  r2-readiness:
+    name: Check R2 bucket availability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      - name: List R2 buckets
+        run: npx wrangler r2 bucket list
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      - name: Check expected backup bucket
+        run: |
+          if npx wrangler r2 bucket list | grep -q "devdrops-backups"; then
+            echo "DEVDROPS_R2_BACKUP_BUCKET=present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "DEVDROPS_R2_BACKUP_BUCKET=missing" >> "$GITHUB_STEP_SUMMARY"
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a manual workflow_dispatch check that uses the existing Cloudflare repo secret to list R2 buckets and report whether devdrops-backups exists.
- Does not bind R2, deploy, change cron, or run backup writes.

## Safety
- No secrets printed by repo code.
- No destructive D1/R2 changes.
- No paid x402 transaction.
- No real AI.
- No cron changes.
