### PR TITLE
Extend R2 setup and paid x402 readiness workflows

### DIFF
--- a/.github/workflows/r2-readiness.yml
+++ b/.github/workflows/r2-readiness.yml
@@ -2,10 +2,15 @@ name: R2 Backup Readiness
 
 on:
   workflow_dispatch:
+    inputs:
+      create_if_missing:
+        description: Create devdrops-backups if it is missing
+        required: false
+        default: "true"
 
 jobs:
   r2-readiness:
-    name: Check R2 bucket availability
+    name: Check or create R2 backup bucket
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,16 +19,45 @@ jobs:
           node-version: "24"
           cache: "npm"
       - run: npm ci
-      - name: List R2 buckets
-        run: npx wrangler r2 bucket list
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      - name: Check expected backup bucket
+      - name: Validate Cloudflare token
         run: |
-          if npx wrangler r2 bucket list | grep -q "devdrops-backups"; then
-            echo "DEVDROPS_R2_BACKUP_BUCKET=present" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "DEVDROPS_R2_BACKUP_BUCKET=missing" >> "$GITHUB_STEP_SUMMARY"
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "Missing required secret: CLOUDFLARE_API_TOKEN"
+            exit 1
           fi
+          echo "CLOUDFLARE_API_TOKEN: present"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      - name: Check/create expected backup bucket
+        run: |
+          set -euo pipefail
+          bucket="devdrops-backups"
+          echo "Listing R2 buckets..."
+          npx wrangler r2 bucket list | tee /tmp/r2-buckets.txt
+          if grep -q "name:           ${bucket}" /tmp/r2-buckets.txt; then
+            echo "DEVDROPS_R2_BACKUP_BUCKET=present" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "DEVDROPS_R2_BACKUP_BUCKET=missing" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${CREATE_IF_MISSING}" != "true" ]; then
+            echo "Creation disabled by workflow input."
+            exit 0
+          fi
+          echo "Creating ${bucket}..."
+          npx wrangler r2 bucket create "${bucket}"
+          npx wrangler r2 bucket list | tee /tmp/r2-buckets-after.txt
+          grep -q "name:           ${bucket}" /tmp/r2-buckets-after.txt
+          echo "DEVDROPS_R2_BACKUP_BUCKET=created" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CREATE_IF_MISSING: ${{ github.event.inputs.create_if_missing }}
+      - name: Verify config binding status
+        run: |
+          if grep -q 'binding.*STORAGE' wrangler.jsonc wrangler.toml && grep -q 'devdrops-backups' wrangler.jsonc wrangler.toml; then
+            echo "CONFIG_STORAGE_BINDING=present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "CONFIG_STORAGE_BINDING=missing" >> "$GITHUB_STEP_SUMMARY"
+            echo "Bucket may exist, but Worker backup is not active until STORAGE binding is committed and deployed."
+          fi
+      - name: Production health check
+        run: curl -sS https://api.devdrops.run/health

--- a/.github/workflows/x402-paid-readiness.yml
+++ b/.github/workflows/x402-paid-readiness.yml
@@ -1,0 +1,30 @@
+name: x402 Paid Smoke Readiness
+
+on:
+  workflow_dispatch:
+
+jobs:
+  readiness:
+    name: Check paid smoke prerequisites only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Check funded smoke wallet secret presence without printing value
+        run: |
+          if [ -z "$X402_SMOKE_PRIVATE_KEY" ]; then
+            echo "X402_SMOKE_PRIVATE_KEY=missing" >> "$GITHUB_STEP_SUMMARY"
+            echo "Missing required secret: X402_SMOKE_PRIVATE_KEY"
+            exit 1
+          fi
+          echo "X402_SMOKE_PRIVATE_KEY=present" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          X402_SMOKE_PRIVATE_KEY: ${{ secrets.X402_SMOKE_PRIVATE_KEY }}
+      - name: Check public discovery surfaces only
+        run: |
+          curl -fsS https://api.devdrops.run/catalog >/tmp/catalog.json
+          curl -fsS https://api.devdrops.run/.well-known/x402 >/tmp/x402.json
+          node -e 'const c=require("/tmp/catalog.json"); if(c.product_count!==43) process.exit(1); console.log("catalog_count=43")'
+          echo "No paid transaction was run by this readiness workflow."

--- a/docs/devdrops-paid-x402-smoke.md
+++ b/docs/devdrops-paid-x402-smoke.md
@@ -1,0 +1,38 @@
+# Paid x402 Smoke Readiness
+
+This runbook is for the first explicitly approved paid DevDrops transaction.
+
+## Required Secret
+
+Use a dedicated low-balance smoke wallet secret. Recommended name:
+
+```text
+X402_SMOKE_PRIVATE_KEY
+```
+
+Do not reuse production treasury wallets. Do not print the value. Do not write it to logs, artifacts, summaries, or frontend code.
+
+## Network And Funding
+
+- Chain/network: Base mainnet (`eip155:8453`)
+- Currency: USDC
+- Minimum practical balance: enough USDC for one low-cost endpoint plus gas/settlement buffer
+- Recommended first endpoint: a low-cost non-AI endpoint from `/catalog`, such as `/api/fx/latest` after free-tier quota is exhausted or another `$0.001`/`$0.005` endpoint
+
+## Safe Transaction Path
+
+1. Confirm `/catalog` and `/.well-known/x402` are healthy.
+2. Probe the chosen paid endpoint without payment and confirm HTTP `402`.
+3. Build the x402 payment proof locally in the workflow or operator machine without echoing wallet material.
+4. Retry the same endpoint with the payment header.
+5. Confirm HTTP `200` and structured JSON.
+6. Verify a D1 `transactions` row exists.
+7. Check x402scan indexing after settlement.
+
+## Guardrails
+
+- Never run this on pull requests.
+- Never run automatically on schedule.
+- Never include the private key in command output.
+- Never use an AI endpoint for the first payment smoke.
+- Do not add a production payment bypass.


### PR DESCRIPTION
## Summary
- Extends the R2 readiness workflow so it can create the devdrops-backups bucket when Cloudflare credentials allow it.
- Adds config binding diagnostics so bucket creation and Worker activation remain explicit.
- Adds paid x402 smoke readiness docs and a workflow that checks for a dedicated X402_SMOKE_PRIVATE_KEY without running a transaction.

## Safety
- No destructive R2/D1 actions.
- No bucket/object deletion.
- No wallet/private key exposure.
- No paid transaction.
- No real AI.
- No cron changes.
