### PR TITLE
Bind DevDrops R2 backup bucket

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,6 +18,9 @@
   "d1_databases": [
     { "binding": "DB", "database_name": "devdrops", "database_id": "dc92b44a-7d5e-46f1-b7cc-865328f8d42e" }
   ],
+  "r2_buckets": [
+    { "binding": "STORAGE", "bucket_name": "devdrops-backups" }
+  ],
   "ai": { "binding": "AI" },
   "kv_namespaces": [
     { "binding": "CACHE", "id": "7973d723cbf349c2874eece54b651d49" }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,10 +17,10 @@ binding = "DB"
 database_name = "devdrops"
 database_id = "dc92b44a-7d5e-46f1-b7cc-865328f8d42e"
 
-# R2 Bucket (backups + document storage) — uncomment once R2 is enabled in Cloudflare dashboard
-# [[r2_buckets]]
-# binding = "STORAGE"
-# bucket_name = "devdrops-backups"
+# R2 Bucket (nightly D1 backups; non-destructive object writes only)
+[[r2_buckets]]
+binding = "STORAGE"
+bucket_name = "devdrops-backups"
 
 # Cloudflare Workers AI
 [ai]


### PR DESCRIPTION
## Summary
- Enables the STORAGE R2 binding for the existing devdrops-backups bucket.
- Does not delete buckets/objects or change D1 data.
- Keeps existing cron schedule; backup job already writes only export objects and skips safely when unavailable.

## Validation
- npm run typecheck
- npx wrangler deploy --dry-run --env=""

## Safety
- Destructive R2/D1 changes: no
- Bucket/object deletion: no
- Secrets exposed: no
- Paid transaction: no
- Real AI: no
- Payment flow changed: no
